### PR TITLE
Merge "work-page" to main

### DIFF
--- a/src/components/home/homeWork.js
+++ b/src/components/home/homeWork.js
@@ -9,17 +9,17 @@ import Col from "react-bootstrap/Col";
 import { TitleCard } from "../../components"
 import { workCreativeBG, workDevBG, workVideoBG } from '../../media/home'
 
+const SKILLS_TEXT_ARRAY = ["Python", "JavaScript", "Ruby", "React", "HTML/CSS", "Ruby on Rails", "Shell Scripting", "FFmpeg", "Final Cut Pro", "Premiere Pro", "After Effects"]
+
+const TITLE_CARD_INFO = [
+  {title: <>SOFTWARE &amp; <br/> WEB DEV</>, background: workDevBG, alt:'Software and Web Development Card', category: 'Software'},
+  {title:'VIDEO PRODUCTION', background: workVideoBG, alt:'Video Production Card', category: 'Video'},
+  {title:'CREATIVE PROJECTS', background: workCreativeBG, alt:'Creative Projects Card', category: 'Creative'}
+]
+
 const HomeWork = () => {
 
-  const skillsTextArray = ["Python", "JavaScript", "Ruby", "React", "HTML/CSS", "Ruby on Rails", "Shell Scripting", "FFmpeg", "Final Cut Pro", "Premiere Pro", "After Effects"]
-
-  const titleCardInfo = [
-    {title: <>SOFTWARE &amp; <br/> WEB DEV</>, background: workDevBG, alt:'Software and Web Development Card', category: 'Software'},
-    {title:'VIDEO PRODUCTION', background: workVideoBG, alt:'Video Production Card', category: 'Video'},
-    {title:'CREATIVE PROJECTS', background: workCreativeBG, alt:'Creative Projects Card', category: 'Creative'}
-  ]
-
-  const titleCards = titleCardInfo.map(({title, background, alt, category}) =>
+  const titleCards = TITLE_CARD_INFO.map(({title, background, alt, category}) =>
     <Col lg="4">
       <Link to="/work" state={{fromLink: category}}>
         <TitleCard {...{title, background, alt}}></TitleCard>
@@ -32,11 +32,11 @@ const HomeWork = () => {
   
     useInterval(() => {
       let index = skillsTextIndex
-      index = ++index % skillsTextArray.length
+      index = ++index % SKILLS_TEXT_ARRAY.length
       setskillsTextIndex(index);
     }, 1150);
   
-    return skillsTextArray[skillsTextIndex]
+    return SKILLS_TEXT_ARRAY[skillsTextIndex]
   }
   
   return (

--- a/src/components/home/homeWork.js
+++ b/src/components/home/homeWork.js
@@ -14,14 +14,16 @@ const HomeWork = () => {
   const skillsTextArray = ["Python", "JavaScript", "Ruby", "React", "HTML/CSS", "Ruby on Rails", "Shell Scripting", "FFmpeg", "Final Cut Pro", "Premiere Pro", "After Effects"]
 
   const titleCardInfo = [
-    {title: <>SOFTWARE &amp; <br/> WEB DEV</>, background: workDevBG, alt:'Software and Web Development Card'},
-    {title:'VIDEO PRODUCTION', background: workVideoBG, alt:'Video Production Card'},
-    {title:'CREATIVE PROJECTS', background: workCreativeBG, alt:'Creative Projects Card'}
+    {title: <>SOFTWARE &amp; <br/> WEB DEV</>, background: workDevBG, alt:'Software and Web Development Card', category: 'Software'},
+    {title:'VIDEO PRODUCTION', background: workVideoBG, alt:'Video Production Card', category: 'Video'},
+    {title:'CREATIVE PROJECTS', background: workCreativeBG, alt:'Creative Projects Card', category: 'Creative'}
   ]
 
-  const titleCards = titleCardInfo.map(({title, background, alt}) =>
+  const titleCards = titleCardInfo.map(({title, background, alt, category}) =>
     <Col lg="4">
+      <Link to="/work" state={{fromLink: category}}>
         <TitleCard {...{title, background, alt}}></TitleCard>
+      </Link>
     </Col>
   );
   

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -31,7 +31,7 @@ const Navigation = ({ socialMediaIcons }) => {
         alt={`${name} Icon`}
         className={`${
           offCanvasToggled
-            ? "nav__social-media-logo--off-canvas mb-5 mx-2 mx-lg-3"
+            ? "nav__social-media-logo--off-canvas mb-4 mx-2 mx-lg-3"
             : null
         } nav__link nav__social-media-logo d-inline-block align-text-top`}
       />
@@ -73,13 +73,13 @@ const Navigation = ({ socialMediaIcons }) => {
             className={`
                   ${
                     offCanvasToggled
-                      ? "mx-auto text-center pt-7"
+                      ? "text-center d-flex flex-column align-items-center"
                       : "pt-2"
                   }
                   ${fadeNav ? "nav--fade-in" : null}
                 `}
           >
-            <Nav className={`justify-content-end flex-grow-1 px-5`}>
+            <Nav className={`${offCanvasToggled ? 'my-auto' : 'flex-grow-1'} justify-content-end px-5`}>
               <Nav.Link
                 className={`nav__link ${
                   offCanvasToggled ? "nav__link--off-canvas" : null
@@ -116,15 +116,10 @@ const Navigation = ({ socialMediaIcons }) => {
                 Contact
               </Nav.Link>
             </Nav>
-            {offCanvasToggled ? null : (
-              <Nav>
+              <Nav className={`${offCanvasToggled ? 'pt-3 mt-auto flex-row' : null}`}>
                 {socialMediaList}
               </Nav>
-            )}
           </Offcanvas.Body>
-          {offCanvasToggled ? (
-            <Nav className="mx-auto flex-row">{socialMediaList}</Nav>
-          ) : null}
         </Navbar.Offcanvas>
       </Container>
     </Navbar>

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -5,14 +5,14 @@ import Navbar from "react-bootstrap/Navbar";
 import Offcanvas from "react-bootstrap/Offcanvas";
 import { Link } from "gatsby";
 
-const Navigation = (props) => {
+const Navigation = ({ socialMediaIcons }) => {
   const [offCanvasToggled, setOffCanvasToggled] = useState(false);
   const [offCanvasExited, setOffCanvasExited] = useState(true);
   const [fadeNav, setFadeNav] = useState(false);
 
   const handleEnter = () => {
     setOffCanvasToggled(true);
-    setOffCanvasExited(false)
+    setOffCanvasExited(false);
     setFadeNav(false);
   };
   const handleExiting = () => {
@@ -21,13 +21,20 @@ const Navigation = (props) => {
   };
   const handleExited = () => {
     setOffCanvasExited(true);
-  }
+  };
   const expand = "md";
-  const socialMediaIcons = props.socialMediaIcons;
 
   const socialMediaList = socialMediaIcons.map(({ name, link, SVGComp }) => (
     <Navbar.Brand href={link} aria-label={name}>
-      <SVGComp role="img" alt={`${name} Icon`} className="d-inline-block align-text-top"/>
+      <SVGComp
+        role="img"
+        alt={`${name} Icon`}
+        className={`${
+          offCanvasToggled
+            ? "nav__social-media-logo--off-canvas mb-5 mx-2 mx-lg-3"
+            : null
+        } nav__link nav__social-media-logo d-inline-block align-text-top`}
+      />
     </Navbar.Brand>
   ));
 
@@ -40,7 +47,7 @@ const Navigation = (props) => {
       style={{ backgroundColor: "transparent" }}
     >
       <Container fluid>
-        <Navbar.Brand className="site-logo" as={Link} to="/">
+        <Navbar.Brand className="nav__site-logo" as={Link} to="/">
           <p className="pt-3 ps-4">AW</p>
         </Navbar.Brand>
         <Navbar.Toggle
@@ -66,28 +73,58 @@ const Navigation = (props) => {
             className={`
                   ${
                     offCanvasToggled
-                      ? "mx-auto text-center nav-offcanvas pt-5 my-auto"
-                      : "nav-top pt-2"
+                      ? "mx-auto text-center pt-7"
+                      : "pt-2"
                   }
-                  ${fadeNav ? "nav-fade" : null}
+                  ${fadeNav ? "nav--fade-in" : null}
                 `}
           >
             <Nav className={`justify-content-end flex-grow-1 px-5`}>
-              <Nav.Link as={Link} to="/work">
+              <Nav.Link
+                className={`nav__link ${
+                  offCanvasToggled ? "nav__link--off-canvas" : null
+                }`}
+                as={Link}
+                to="/work"
+              >
                 Work
               </Nav.Link>
-              <Nav.Link as={Link} to="/about">
+              <Nav.Link
+                className={`nav__link ${
+                  offCanvasToggled ? "nav__link--off-canvas" : null
+                }`}
+                as={Link}
+                to="/about"
+              >
                 About
               </Nav.Link>
-              <Nav.Link href="https://artwilton.medium.com">Blog</Nav.Link>
-              <Nav.Link as={Link} to="/contact">
+              <Nav.Link
+                className={`nav__link ${
+                  offCanvasToggled ? "nav__link--off-canvas" : null
+                }`}
+                href="https://artwilton.medium.com"
+              >
+                Blog
+              </Nav.Link>
+              <Nav.Link
+                className={`nav__link ${
+                  offCanvasToggled ? "nav__link--off-canvas" : null
+                }`}
+                as={Link}
+                to="/contact"
+              >
                 Contact
               </Nav.Link>
             </Nav>
-            <Nav className="flex-row justify-content-evenly">
-              {socialMediaList}
-            </Nav>
+            {offCanvasToggled ? null : (
+              <Nav>
+                {socialMediaList}
+              </Nav>
+            )}
           </Offcanvas.Body>
+          {offCanvasToggled ? (
+            <Nav className="mx-auto flex-row">{socialMediaList}</Nav>
+          ) : null}
         </Navbar.Offcanvas>
       </Container>
     </Navbar>

--- a/src/components/workCard.js
+++ b/src/components/workCard.js
@@ -12,10 +12,10 @@ const WorkCard = ({name, description, imgSource, imgAlt}) => {
                             <Col md="5" lg="4">
                             <img className="work-card__image" src={imgSource} alt={imgAlt}/>
                             </Col>
-                            <Col className="d-flex flex-column" md="7" lg="8">
+                            <Col className="d-flex flex-column text-md-start" md="7" lg="8">
                                 <Card.Body >
                                     <Card.Title as="h4">{name}</Card.Title>
-                                    <Card.Text className="work-card__description py-2">{description}</Card.Text>
+                                    <Card.Text className="work-card__description py-1 pb-sm-2 pb-lg-3">{description}</Card.Text>
                                 </Card.Body>
                                 <Row className="mb-3">
                                     <Col className="col-auto me-auto ms-3">

--- a/src/components/workCard.js
+++ b/src/components/workCard.js
@@ -4,21 +4,18 @@ import { Link } from "gatsby";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Card from "react-bootstrap/Card";
-import Button from "react-bootstrap/Button";
 
-import { workCreativeBG } from "../media/home";
-
-const WorkCard = () => {
+const WorkCard = ({name, description, imgSource, imgAlt}) => {
     return (
                     <Card className="work-card border-0 shadow-sm">
                         <Row className="g-0">
                             <Col md="5" lg="4">
-                            <img className="work-card__image" src={workCreativeBG} alt="..."/>
+                            <img className="work-card__image" src={imgSource} alt={imgAlt}/>
                             </Col>
                             <Col className="d-flex flex-column" md="7" lg="8">
                                 <Card.Body >
-                                    <Card.Title as="h4">Project Name</Card.Title>
-                                    <Card.Text className="work-card__description py-2">FCPX Marker Tool is written in Python, and allows for parsing, displaying, and saving marker metadata from FCPXML files in both .fcpxml and .fcpxmld formats.</Card.Text>
+                                    <Card.Title as="h4">{name}</Card.Title>
+                                    <Card.Text className="work-card__description py-2">{description}</Card.Text>
                                 </Card.Body>
                                 <Row className="mb-3">
                                     <Col className="col-auto me-auto ms-3">

--- a/src/components/workCard.js
+++ b/src/components/workCard.js
@@ -17,12 +17,12 @@ const WorkCard = ({name, description, imgSource, imgAlt}) => {
                                     <Card.Title as="h4">{name}</Card.Title>
                                     <Card.Text className="work-card__description py-1 pb-sm-2 pb-lg-3">{description}</Card.Text>
                                 </Card.Body>
-                                <Row className="mb-3">
-                                    <Col className="col-auto me-auto ms-3">
-                                        <Link to="/" className="btn btn-sm btn-dark shadow-none">Read More</Link>
+                                <Row className="mb-3 mx-auto mx-md-0 px-1 g-2 g-md-4">
+                                    <Col className="col-auto mx-auto mx-md-0">
+                                        <Link to="/" className="work-card__button btn btn-sm btn-dark shadow-none">Read More</Link>
                                     </Col>
-                                    <Col className="col-auto me-3">
-                                        <Link to="/about" className=" btn btn-outline-dark btn-sm">Watch Demo ▶</Link>
+                                    <Col className="col-auto mx-auto mx-md-0">
+                                        <Link to="/about" className="work-card__button btn btn-outline-dark btn-sm">Watch Demo ▶</Link>
                                     </Col>
                                 </Row>
                             </Col>

--- a/src/pages/work.js
+++ b/src/pages/work.js
@@ -20,6 +20,7 @@ const FILTER_NAMES = Object.keys(FILTER_MAP);
 
 const PROJECTS_ARRAY = [
   {
+    id: 1,
     name: "Software Example",
     description:
       "FCPX Marker Tool is written in Python, and allows for parsing, displaying, and saving marker metadata from FCPXML files in both .fcpxml and .fcpxmld formats.",
@@ -28,6 +29,7 @@ const PROJECTS_ARRAY = [
     category: "Software",
   },
   {
+    id: 2,
     name: "Video Example",
     description:
       "FCPX Marker Tool is written in Python, and allows for parsing, displaying, and saving marker metadata from FCPXML files in both .fcpxml and .fcpxmld formats.",
@@ -36,6 +38,7 @@ const PROJECTS_ARRAY = [
     category: "Video",
   },
   {
+    id: 3,
     name: "Creative Example",
     description:
       "FCPX Marker Tool is written in Python, and allows for parsing, displaying, and saving marker metadata from FCPXML files in both .fcpxml and .fcpxmld formats.",
@@ -50,8 +53,9 @@ const WorkPage = ({ location }) => {
     location.state.fromLink ? location.state.fromLink : "All"
   );
 
-  const filterList = FILTER_NAMES.map((name) => (
+  const filterButtonList = FILTER_NAMES.map((name) => (
     <ToggleButton
+      variant="light"
       key={name}
       id={name}
       value={name}
@@ -63,10 +67,10 @@ const WorkPage = ({ location }) => {
   ));
 
   const workCardsFiltered = PROJECTS_ARRAY.filter(FILTER_MAP[filter]).map(
-    ({ name, description, imgSource, imgAlt, category }) => (
+    ({ id, name, description, imgSource, imgAlt, category }) => (
       <WorkCard
         key={name}
-        {...{ name, description, imgSource, imgAlt, category }}
+        {...{ id, name, description, imgSource, imgAlt, category }}
       />
     )
   );
@@ -76,15 +80,19 @@ const WorkPage = ({ location }) => {
       <Container fluid>
         <Row className="cover-section__bg--dark pt-5 pb-4 py-md-5">
           <Col xs="7" md="5" className="mx-auto mt-4 mb-2 mt-md-6 mb-md-3">
-            <h1 className="text-center border-bottom border-light pb-2 pb-md-3">
+            <h1 className="work__header text-center border-bottom border-light pb-2 pb-md-3">
               My Work
             </h1>
           </Col>
         </Row>
-        <Row className="main-content__bg--light py-5">
-          <ToggleButtonGroup type="radio" name="options" defaultValue={filter}>
-            {filterList}
-          </ToggleButtonGroup>
+        <Row className="main-content__bg--light py-5 justify-content-center text-center">
+          <Row>
+            <Col xs="10" className="mx-auto g-0 py-md-1 pb-md-2">
+              <ToggleButtonGroup className="shadow-lg-light" type="radio" name="options" defaultValue={filter}>
+                {filterButtonList}
+              </ToggleButtonGroup>
+            </Col>
+          </Row>
           <Col xs="10" className="mx-auto d-grid gap-4 pt-5">
             {workCardsFiltered}
           </Col>

--- a/src/pages/work.js
+++ b/src/pages/work.js
@@ -55,6 +55,7 @@ const WorkPage = ({ location }) => {
 
   const filterButtonList = FILTER_NAMES.map((name) => (
     <ToggleButton
+      className="filter-button-group__button"
       variant="light"
       key={name}
       id={name}
@@ -85,15 +86,15 @@ const WorkPage = ({ location }) => {
             </h1>
           </Col>
         </Row>
-        <Row className="main-content__bg--light py-5 justify-content-center text-center">
-          <Row>
+        <Row className="main-content__bg--light py-4 py-md-5 justify-content-center text-center">
+          <Row >
             <Col xs="10" className="mx-auto g-0 py-md-1 pb-md-2">
-              <ToggleButtonGroup className="shadow-lg-light" type="radio" name="options" defaultValue={filter}>
+              <ToggleButtonGroup className="filter-button-group shadow-lg-light" type="radio" name="options" defaultValue={filter}>
                 {filterButtonList}
               </ToggleButtonGroup>
             </Col>
           </Row>
-          <Col xs="10" className="mx-auto d-grid gap-4 pt-5">
+          <Col xs="10" className="mx-auto d-grid gap-4 pt-4 pt-md-5">
             {workCardsFiltered}
           </Col>
         </Row>

--- a/src/pages/work.js
+++ b/src/pages/work.js
@@ -1,30 +1,99 @@
-import * as React from "react"
-import {Layout, WorkCard} from "../components"
+import React, { useState } from "react";
+import { Layout, WorkCard } from "../components";
 
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
+import ToggleButton from "react-bootstrap/ToggleButton";
+import ToggleButtonGroup from "react-bootstrap/ToggleButtonGroup";
 
-const WorkPage = () => {
-    return (
-        <Layout>
-            <Container fluid>
-            <Row className="cover-section__bg--dark pt-5 pb-4 py-md-5">
-                <Col xs="7" md="5" className="mx-auto mt-4 mb-2 mt-md-6 mb-md-3">
-                <h1 className="text-center border-bottom border-light pb-2 pb-md-3">My Work</h1>
-                </Col>
-            </Row>
-            <Row className="main-content__bg--light py-5">
-                <Col xs="10" className="mx-auto d-grid gap-4">
-                    <WorkCard/>
-                    <WorkCard/>
-                </Col>
-            </Row>
-        </Container>
-        </Layout>
+import { workCreativeBG } from "../media/home";
+
+const FILTER_MAP = {
+  All: () => true,
+  Software: (project) => project.category === "Software",
+  Video: (project) => project.category === "Video",
+  Creative: (project) => project.category === "Creative",
+};
+
+const FILTER_NAMES = Object.keys(FILTER_MAP);
+
+const PROJECTS_ARRAY = [
+  {
+    name: "Software Example",
+    description:
+      "FCPX Marker Tool is written in Python, and allows for parsing, displaying, and saving marker metadata from FCPXML files in both .fcpxml and .fcpxmld formats.",
+    imgSource: workCreativeBG,
+    imgAlt: "FCPX Marker Tool Icon",
+    category: "Software",
+  },
+  {
+    name: "Video Example",
+    description:
+      "FCPX Marker Tool is written in Python, and allows for parsing, displaying, and saving marker metadata from FCPXML files in both .fcpxml and .fcpxmld formats.",
+    imgSource: workCreativeBG,
+    imgAlt: "FCPX Marker Tool Icon",
+    category: "Video",
+  },
+  {
+    name: "Creative Example",
+    description:
+      "FCPX Marker Tool is written in Python, and allows for parsing, displaying, and saving marker metadata from FCPXML files in both .fcpxml and .fcpxmld formats.",
+    imgSource: workCreativeBG,
+    imgAlt: "FCPX Marker Tool Icon",
+    category: "Creative",
+  },
+];
+
+const WorkPage = ({ location }) => {
+  const [filter, setFilter] = useState(
+    location.state.fromLink ? location.state.fromLink : "All"
+  );
+
+  const filterList = FILTER_NAMES.map((name) => (
+    <ToggleButton
+      key={name}
+      id={name}
+      value={name}
+      aria-pressed={name === filter}
+      onChange={() => setFilter(name)}
+    >
+      {name}
+    </ToggleButton>
+  ));
+
+  const workCardsFiltered = PROJECTS_ARRAY.filter(FILTER_MAP[filter]).map(
+    ({ name, description, imgSource, imgAlt, category }) => (
+      <WorkCard
+        key={name}
+        {...{ name, description, imgSource, imgAlt, category }}
+      />
     )
-}
+  );
 
-export default WorkPage
+  return (
+    <Layout>
+      <Container fluid>
+        <Row className="cover-section__bg--dark pt-5 pb-4 py-md-5">
+          <Col xs="7" md="5" className="mx-auto mt-4 mb-2 mt-md-6 mb-md-3">
+            <h1 className="text-center border-bottom border-light pb-2 pb-md-3">
+              My Work
+            </h1>
+          </Col>
+        </Row>
+        <Row className="main-content__bg--light py-5">
+          <ToggleButtonGroup type="radio" name="options" defaultValue={filter}>
+            {filterList}
+          </ToggleButtonGroup>
+          <Col xs="10" className="mx-auto d-grid gap-4 pt-5">
+            {workCardsFiltered}
+          </Col>
+        </Row>
+      </Container>
+    </Layout>
+  );
+};
 
-export const Head = () => <title>Work</title>
+export default WorkPage;
+
+export const Head = () => <title>Work</title>;

--- a/src/styles/customized-bootstrap-styles.scss
+++ b/src/styles/customized-bootstrap-styles.scss
@@ -26,7 +26,7 @@ $btn-font-weight: 200;
 $btn-white-space: nowrap;
 
 
-$btn-border-radius: 6px;
+$btn-border-radius: 5px;
 $btn-padding-y: 0;
 $btn-border-radius-lg: 0;
 $btn-padding-y-lg: 0;

--- a/src/styles/customized-bootstrap-styles.scss
+++ b/src/styles/customized-bootstrap-styles.scss
@@ -19,7 +19,7 @@ $lead-font-weight: 200;
 $btn-font-family: gill-sans-nova, Gill Sans,Gill Sans MT,Calibri,sans-serif;
 
 $btn-font-size-lg: 2.2rem;
-$btn-font-size: 1.8rem;
+$btn-font-size: 1.7rem;
 $btn-font-size-sm: 1.4rem;
 $btn-border-width: .15rem;
 $btn-font-weight: 200;

--- a/src/styles/customized-bootstrap-styles.scss
+++ b/src/styles/customized-bootstrap-styles.scss
@@ -19,13 +19,15 @@ $lead-font-weight: 200;
 $btn-font-family: gill-sans-nova, Gill Sans,Gill Sans MT,Calibri,sans-serif;
 
 $btn-font-size-lg: 2.2rem;
+$btn-font-size: 1.8rem;
 $btn-font-size-sm: 1.4rem;
 $btn-border-width: .15rem;
 $btn-font-weight: 200;
 $btn-white-space: nowrap;
 
 
-$btn-border-radius: 0;
+$btn-border-radius: 6px;
+$btn-padding-y: 0;
 $btn-border-radius-lg: 0;
 $btn-padding-y-lg: 0;
 $btn-border-radius-sm: 0;
@@ -57,7 +59,30 @@ $custom-spacer: .75rem;
 @import "/node_modules/bootstrap/scss/root";
 
 // Optional Bootstrap components
-// @import "/node_modules/bootstrap/scss/utilities";
+@import "/node_modules/bootstrap/scss/utilities";
+
+$box-shadow-light: 0 .5rem 1rem rgba($black, .075);
+$box-shadow-sm-light: 0 .125rem .25rem rgba($black, .04);
+$box-shadow-lg-light: 0 1rem 3rem rgba($black, .075);
+
+$utilities: map-merge(
+  $utilities,
+  (
+    "shadow": map-merge(
+      map-get($utilities, "shadow"),
+      (
+        values: map-merge(
+          map-get(map-get($utilities, "shadow"), "values"),
+          (
+            'light': $box-shadow-light,
+            'sm-light': $box-shadow-sm-light,
+            'lg-light': $box-shadow-lg-light
+          )
+        ),
+      ),
+    ),
+  )
+);
 // @import "/node_modules/bootstrap/scss/reboot";
 // @import "/node_modules/bootstrap/scss/type";
 // @import "/node_modules/bootstrap/scss/buttons";

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -261,12 +261,13 @@ $color--dark: #161619;
 
 /* Work Page */
 .work-card {
-  max-width: 1200px;
+  max-width: 1100px;
   margin-left: auto;
   margin-right: auto;
   @include element('image') {
     width: 100%;
     height: 100%;
+    max-height: 420px;
     object-fit: cover;
   }
   @include element('title') {
@@ -274,6 +275,19 @@ $color--dark: #161619;
   }
   @include element('description') {
     font-size: 1.4rem;
+    @include media-breakpoint-down(md) {
+      font-size: 1.3rem;
+      }
+    @include media-breakpoint-down(sm) {
+      font-size: 1.2rem;
+    }
+  }
+}
+
+.work {
+  @include element('header') {
+    @include font-smoothing;
+    font-weight: 700;
   }
 }
 

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -52,27 +52,36 @@ $color--dark: #161619;
 
 /* NavBar and OffCanvas */
 
-.nav-fade {
-  @include fade-in;
-}
-
-.nav-top .nav-link, svg {
-  font-size: 1.2em;
-}
-
-.nav-top svg {
-  color: $color--light;
-}
-
-.nav-offcanvas {
-  font-size: 2.2em;
-}
-
-.nav--under-logo {
-  position: absolute;
-  z-index: auto;
-  top: 0px;
-  right: 0px;
+.nav {
+  @include element('site-logo') {
+    z-index: 9999;
+    position: fixed;
+    top: 0px;
+    left: 0px;
+  }
+  @include element('link') {
+    font-size: 1.2em;
+    color: $color--light;
+    @include modifier('off-canvas') {
+      @include font-size(4.2rem);
+      padding-top: 0rem;
+      padding-bottom: 0rem;
+    }
+  }
+  @include element('social-media-logo') {
+    @include modifier('off-canvas') {
+      @include font-size(4rem);
+    }
+  }
+  @include modifier('fade-in') {
+    @include fade-in;
+  }
+  @include modifier('under-logo') {
+    position: absolute;
+    z-index: auto;
+    top: 0px;
+    right: 0px;
+  }
 }
 
 // default bootstrap Nav values for reference
@@ -80,33 +89,6 @@ $color--dark: #161619;
 //   position: fixed;
 //   z-index: 1030;
 // }
-
-.site-logo {
-  z-index: 9999;
-  position: fixed;
-  top: 0px;
-  left: 0px;
-}
-
-.navbar-toggler {
-  position: fixed;
-  top: 0px;
-  right: 0px;
-}
-
-.nav--under-logo {
-  position: absolute;
-  z-index: auto;
-  top: 0px;
-  right: 0px;
-}
-
-.site-logo {
-  z-index: 9999;
-  position: fixed;
-  top: 0px;
-  left: 0px;
-}
 
 .navbar-toggler {
   position: fixed;
@@ -293,6 +275,19 @@ $color--dark: #161619;
   @include element('header') {
     @include font-smoothing;
     font-weight: 700;
+  }
+}
+
+.filter-button-group {
+  @include element('button') {
+    @include media-breakpoint-down(md) {
+      font-size: 1.5rem;
+    }
+    @include media-breakpoint-down(sm) {
+      padding-left: .5rem;
+      padding-right: .5rem;
+      font-size: 1.2rem;
+    }
   }
 }
 

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -279,6 +279,11 @@ $color--dark: #161619;
       font-size: 1.3rem;
       }
     @include media-breakpoint-down(sm) {
+      font-size: 1.1rem;
+    }
+  }
+  @include element('button') {
+    @include media-breakpoint-down(sm) {
       font-size: 1.2rem;
     }
   }

--- a/src/styles/global-styles.scss
+++ b/src/styles/global-styles.scss
@@ -70,7 +70,7 @@ $color--dark: #161619;
   }
   @include element('social-media-logo') {
     @include modifier('off-canvas') {
-      @include font-size(4rem);
+      @include font-size(3rem);
     }
   }
   @include modifier('fade-in') {


### PR DESCRIPTION
Updated the Work page to allow for filtering based on category. I added state using the location prop to automatically enable to correct filter when linking from another page, for example clicking the "creative" link on the main page will enable to "creative" filter on the work page when navigating there.

Minor updates to Work Card styling were added, as well as custom bootstrap shadow styling for less opaque shadows behind the filter buttons.